### PR TITLE
Fix issue #1

### DIFF
--- a/src/components/table/TableContent.tsx
+++ b/src/components/table/TableContent.tsx
@@ -32,8 +32,8 @@ const TableContent = ({
     // columnResizingOffset,
     // updateColumn,
     // reorderColumns,
-    // handleUpdateRowNoRender,
-    handleUpdateRow,
+    handleUpdateRowNoRender,
+    // handleUpdateRow,
     handleDeleteBoxChange,
     rowCallUpdate,
     showDoneRows = false,
@@ -300,8 +300,8 @@ const TableContent = ({
     const handleChange = (row: any) => {
         // handleUpdateRow(row);
 
-        // setCurrentRows((prev) => prev.map((prevRow) => (prevRow._id === row._id ? row : prevRow)));
-        handleUpdateRow(row);
+        setCurrentRows((prev) => prev.map((prevRow) => (prevRow._id === row._id ? row : prevRow)));
+        handleUpdateRowNoRender(row);
     };
 
     const handleSubrowVisibility = (row: any) => {

--- a/src/features/dataCollections/DataCollection.tsx
+++ b/src/features/dataCollections/DataCollection.tsx
@@ -26,7 +26,7 @@ const DataCollection = ({ showDoneRows = false }: { showDoneRows?: boolean }) =>
 
     const {
         data: rowsData,
-        // refetch,
+        refetch,
         isFetching,
         // isLoading,
     } = useGetRowsQuery({ dataCollectionId: dataCollectionId || '', limit: 0, skip: 0, sort: 1, sortBy: 'createdAt' });
@@ -73,9 +73,9 @@ const DataCollection = ({ showDoneRows = false }: { showDoneRows?: boolean }) =>
     //     setRows(rowsData);
     // }, [rowsData, showDoneRows]);
 
-    // useEffect(() => {
-    //     refetch();
-    // }, [showDoneRows]);
+    useEffect(() => {
+        refetch();
+    }, [showDoneRows]);
 
     useEffect(() => {
         getPermissions();


### PR DESCRIPTION
State is now being handled by the TableContent component instead of RTK query. due to the fact that the frontend and backend become out of sync. The new implementation does not force a refetch which keeps the frontend handled by the component state and RTK handles the update request in the backend which keeps both in sync.

A RTK query rows refetch was also implemented in the DataCollection component to refetch the rows when the component is mounted. This is necessary since navigating out of the data collection and then back in without refreshing the browser causes TRK query to fetch the rows from cache which do not have any new updates made to the rows. 